### PR TITLE
修复docker构建过程中css_tag未定义问题

### DIFF
--- a/tools/labs/docker/docs/Dockerfile
+++ b/tools/labs/docker/docs/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get install -y fonts-noto-cjk
 RUN apt-get install -y latexmk
 RUN apt-get install -y librsvg2-bin
 RUN apt-get install -y texlive-xetex
-RUN pip install Sphinx==1.6.7 sphinx_rtd_theme hieroglyph==1.0 Jinja2==2.11.3 markupsafe==2.0.1
+RUN pip install Sphinx==1.6.7 sphinx_rtd_theme==1.3.0 hieroglyph==1.0 Jinja2==2.11.3 markupsafe==2.0.1
 # append new packages here, to minimize docker rebuild time
 RUN rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
问题日志：
```powershell
`ubuntu@e451a0008b86:/linux/tools/labs$ cat /tmp/sphinx-err-y3hu2pfk.log  # Sphinx version: 1.6.7
# Python version: 3.8.10 (CPython)
# Docutils version: 0.20.1 
# Jinja2 version: 2.11.3
# Last messages:
#   
#   looking for now-outdated files...
#   none found
#   pickling environment...
#   done
#   checking consistency...
#   done
#   preparing documents...
#   done
#   writing output... [  1%] index
# Loaded extensions:
#   alabaster (0.7.13) from /usr/local/lib/python3.8/dist-packages/alabaster/__init__.py
#   kerneldoc (1.0) from /linux/Documentation/sphinx/kerneldoc.py
#   rstFlatTable (1.0) from /linux/Documentation/sphinx/rstFlatTable.py
#   kernel_include (1.0) from /linux/Documentation/sphinx/kernel_include.py
#   kfigure (1.0.0) from /linux/Documentation/sphinx/kfigure.py
#   sphinx.ext.ifconfig (1.6.7) from /usr/local/lib/python3.8/dist-packages/sphinx/ext/ifconfig.py
#   automarkup (unknown version) from /linux/Documentation/sphinx/automarkup.py
#   maintainers_include (1.0) from /linux/Documentation/sphinx/maintainers_include.py
#   kernel_abi (1.0) from /linux/Documentation/sphinx/kernel_abi.py
#   cdomain (1.1) from /linux/Documentation/sphinx/cdomain.py
#   sphinx.ext.imgmath (1.6.7) from /usr/local/lib/python3.8/dist-packages/sphinx/ext/imgmath.py
#   hieroglyph (unknown version) from /usr/local/lib/python3.8/dist-packages/hieroglyph/__init__.py
#   ditaa (unknown version) from /linux/Documentation/sphinx/ditaa.py
#   asciicast (unknown version) from /linux/Documentation/sphinx/asciicast.py
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/sphinx/cmdline.py", line 306, in main
    app.build(opts.force_all, filenames)
  File "/usr/local/lib/python3.8/dist-packages/sphinx/application.py", line 339, in build
    self.builder.build_update()
  File "/usr/local/lib/python3.8/dist-packages/sphinx/builders/__init__.py", line 327, in build_update
    self.build(to_build,
  File "/usr/local/lib/python3.8/dist-packages/sphinx/builders/__init__.py", line 395, in build
    self.write(docnames, list(updated_docnames), method)
  File "/usr/local/lib/python3.8/dist-packages/sphinx/builders/__init__.py", line 432, in write
    self._write_serial(sorted(docnames))
  File "/usr/local/lib/python3.8/dist-packages/sphinx/builders/__init__.py", line 441, in _write_serial
    self.write_doc(docname, doctree)
  File "/usr/local/lib/python3.8/dist-packages/sphinx/builders/html.py", line 602, in write_doc
    self.handle_page(docname, ctx, event_arg=doctree)
  File "/usr/local/lib/python3.8/dist-packages/sphinx/builders/html.py", line 990, in handle_page
    output = self.templates.render(templatename, ctx)
  File "/usr/local/lib/python3.8/dist-packages/sphinx/jinja2glue.py", line 176, in render
    return self.environment.get_template(template).render(context)
  File "/usr/local/lib/python3.8/dist-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.8/dist-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/usr/local/lib/python3.8/dist-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "/usr/local/lib/python3.8/dist-packages/sphinx/themes/basic/page.html", line 10, in top-level template code
    {%- extends "layout.html" %}
  File "/usr/local/lib/python3.8/dist-packages/sphinx_rtd_theme/layout.html", line 31, in top-level template code
    {{ css_tag(css_file) }}
  File "/usr/local/lib/python3.8/dist-packages/jinja2/sandbox.py", line 460, in call
    if not __self.is_safe_callable(__obj):
  File "/usr/local/lib/python3.8/dist-packages/jinja2/sandbox.py", line 360, in is_safe_callable
    getattr(obj, "unsafe_callable", False) or getattr(obj, "alters_data", False)
jinja2.exceptions.UndefinedError: 'css_tag' is undefined`
``` 

解决办法：
参照官方的Dockerfile文件，更新sphinx_rtd_theme为1.3.0，解决该问题

参考链接：
https://github.com/linux-kernel-labs/linux/commit/42f075b17b504417297a414ca1d3a07c1946c3fd